### PR TITLE
Use Thread.new sysclose in ruby <= 3.3.5

### DIFF
--- a/lib/io/stream/buffered.rb
+++ b/lib/io/stream/buffered.rb
@@ -74,7 +74,7 @@ module IO::Stream
 		
 		protected
 		
-		if RUBY_VERSION >= "3.3.0"
+		if RUBY_VERSION >= "3.3.0" && RUBY_VERSION <= "3.3.5"
 			def sysclose
 				# https://bugs.ruby-lang.org/issues/20723
 				Thread.new{@io.close}.join


### PR DESCRIPTION
This PR adds an upper version constraint on this Ruby `sysclose` issue necessitating `Thread.new` around IO closure.

The relevant upstream Ruby fix is scheduled to land in 3.3.6 in November (and is already present in HEAD/preview branches.)