### PR TITLE
Directly use `IO#write` from `Buffered#syswrite`.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - On Ruby v3.3+, use `IO#write` directly instead of `IO#write_nonblock`, for better performance.
+
 ## v0.7.0
 
   - Split stream functionality into separate `Readable` and `Writable` modules for better modularity and composition.


### PR DESCRIPTION
Previously there may have been some issues due to OpenSSL compatibility, but those fixes have been upstreamed, let's check if this now works correctly.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
