### PR TITLE
Better error handling in `Buffered#sysread`.

### DIFF
--- a/lib/io/stream/buffered.rb
+++ b/lib/io/stream/buffered.rb
@@ -133,8 +133,7 @@ module IO::Stream
 		
 		# Reads data from the underlying stream as efficiently as possible.
 		def sysread(size, buffer)
-			# Come on Ruby, why couldn't this just return `nil`? EOF is not exceptional. Every file has one.
-			while true
+			while !@io.closed?
 				result = @io.read_nonblock(size, buffer, exception: false)
 				
 				case result
@@ -146,8 +145,10 @@ module IO::Stream
 					return result
 				end
 			end
-		rescue Errno::EBADF
-			raise ::IOError, "stream closed"
+			
+			# Otherwise, the `@io` was closed while reading:
+			# https://github.com/ruby/openssl/issues/798
+			raise ::IOError, "closed stream"
 		end
 	end
 end

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
   - On Ruby v3.3+, use `IO#write` directly instead of `IO#write_nonblock`, for better performance.
+  - `Buffered#sysread` now checks `@io.closed?` before attempting to read, improving error handling.
 
 ## v0.7.0
 


### PR DESCRIPTION
`OpenSSL::SSL::SSLSocket#read_nonblock` can raise `Errno::EBADF` if the IO is closed. However `IO#read_nonblock` raises `IOError`. For consistency's sake, try to improve the error handling.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
