### PR TITLE
Handling of reads at EOF, consistent with stdlib.

### DIFF
--- a/lib/io/stream/readable.rb
+++ b/lib/io/stream/readable.rb
@@ -83,6 +83,17 @@ module IO::Stream
 				until @done
 					fill_read_buffer
 				end
+				
+				if buffer
+					buffer.replace(@read_buffer)
+					@read_buffer.clear
+				else
+					buffer = @read_buffer
+					@read_buffer = StringBuffer.new
+				end
+				
+				# Read without size always returns a non-nil value, even if it is an empty string.
+				return buffer
 			end
 			
 			return consume_read_buffer(size, buffer)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fix EOF behavior to match Ruby IO semantics: `read()` returns empty string `""` at EOF while `read(size)` returns `nil` at EOF.
+
 ## v0.9.0
 
   - Add support for `buffer` parameter in `read`, `read_exactly`, and `read_partial` methods to allow reading into a provided buffer.

--- a/test/io/stream/buffered.rb
+++ b/test/io/stream/buffered.rb
@@ -139,7 +139,17 @@ AUnidirectionalStream = Sus::Shared("a unidirectional stream") do
 			expect(client.read).to be == "Hello World"
 			expect(client).to be(:eof?)
 		end
-
+		
+		it "reads until done" do
+			server.close
+			
+			# Subsequent reads should return nil:
+			expect(client.read(1)).to be_nil
+			
+			# Reading with no length should return an empty string:
+			expect(client.read).to be == ""
+		end
+		
 		it "reads only the amount requested" do
 			server.write "Hello World"
 			server.close
@@ -714,7 +724,7 @@ AUnidirectionalStream = Sus::Shared("a unidirectional stream") do
 	with "#close" do
 		it "should close the stream" do
 			server.close
-			expect(client.read).to be_nil
+			expect(client.read).to be == ""
 			
 			expect(server.closed?).to be_truthy
 			expect(client.closed?).to be_falsey


### PR DESCRIPTION
Fixed EOF behavior in `read` to match Ruby's standard IO semantics. Previously, both `read()` and `read(size)` would return `nil` at EOF. Now `read()` without arguments correctly returns an empty string `""` at EOF, while `read(size)` with a specific size returns `nil` at EOF, exactly matching Ruby's `IO#read` behavior.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
