### PR TITLE
Set minimum OpenSSL version.

### DIFF
--- a/io-stream.gemspec
+++ b/io-stream.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
 	spec.files = Dir.glob(["{context,lib}/**/*", "*.md"], File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.3"
-
+	
 	spec.add_dependency "openssl", ">= 3.3"
 end

--- a/io-stream.gemspec
+++ b/io-stream.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
 	spec.files = Dir.glob(["{context,lib}/**/*", "*.md"], File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.3"
+
+	spec.add_dependency "openssl", ">= 3.3"
 end


### PR DESCRIPTION
Hit `NoMethodError: undefined method 'close_read' for OpenSSL::SSL::SSLSocket` from `Buffered#close_read` on Ruby 3.3.11 and OpenSSL gem 3.2.2.

I propose to require OpenSSL gem 3.3 or later. This requirement can be dropped when Ruby 3.3 is no longer supported.

### Types of Changes

- Bug fix.

### Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).