### PR TITLE
Classify Readable#readable? as async-safe (non-consuming peek)

### DIFF
--- a/lib/io/stream/readable.rb
+++ b/lib/io/stream/readable.rb
@@ -36,7 +36,7 @@ module IO::Stream
 			getbyte: :readable,
 			readline: :readable,
 			readlines: :readable,
-			readable?: :readable,
+			readable?: true,
 			fill_read_buffer: :readable,
 			eof?: :readable,
 			finished?: :readable,


### PR DESCRIPTION
Follow-up to socketry/async-safe#4 ("If it's thread safe it should be acceptable").

`Readable#readable?` is currently classified under the `:readable` guard — the same guard as the consuming reads (`read`, `gets`, `fill_read_buffer`, …). But unlike those, `readable?` never consumes or mutates anything:

- `Readable#readable?` only reads `@finished`, checks `@read_buffer.empty?`, and calls `closed?` — no state is written, no buffer content is consumed.
- `Buffered#readable?` additionally delegates to the underlying IO's `readable?`, which for sockets is `recv_nonblock(1, MSG_PEEK, exception: false)` — a kernel-level peek that consumes nothing (for `SSLSocket` it delegates to the underlying socket, for plain `IO` it is `!closed?`, for `StringIO` `!eof?`).
- Semantically it is documented as "whether there is a **chance** that a read operation will succeed" — an advisory snapshot predicate. A concurrent consuming read can change the answer between the call and the caller acting on it, but that is inherent to any liveness check regardless of guard classification; the result is never corrupted state.

This mirrors the existing `Writable::ASYNC_SAFE` idiom, where the internally-synchronized `write`/`puts`/`flush` are classified `true` (safe, skip tracking).

### Why it matters in practice

`async-http`'s connection pool calls `viable?` → `stream&.readable?` on every checkout, while the pooled connection's background reader fiber (HTTP/2) can legitimately be blocked in a consuming read holding the `:readable` guard — that overlap is async-http's intended design (connection reuse + multiplexing). With `async-safe` monitoring enabled, every concurrent same-host request through a shared pooled connection therefore raises a spurious `Async::Safe::ViolationError (guard: readable)`, e.g. for any Rails app enabling monitoring in dev/test while using the faraday `:async_http` adapter (as ruby_llm >= 1.16.0 documents).

Verified downstream: with only this reclassification applied, 16/16 concurrent buffered HTTP requests and 16/16 concurrent SSE-streaming requests over one shared pooled connection run correctly with monitoring active, while genuine concurrent consuming reads still raise `ViolationError` (the guard on all consuming methods is untouched).

Deliberately **not** touching `eof?`/`finished?` — those can block and fill the read buffer, so their guard is legitimate.
