### PR TITLE
Normalize abrupt TLS EOF during non-blocking reads

### DIFF
--- a/lib/io/stream/buffered.rb
+++ b/lib/io/stream/buffered.rb
@@ -107,28 +107,40 @@ module IO::Stream
 		
 		# Attempts to read data from the underlying stream without blocking.
 		def sysread_nonblock(size, buffer)
-			return @io.read_nonblock(size, buffer, exception: false)
+			normalize_read_errors do
+				@io.read_nonblock(size, buffer, exception: false)
+			end
 		end
 		
 		# Reads data from the underlying stream as efficiently as possible.
 		def sysread(size, buffer)
-			# Come on Ruby, why couldn't this just return `nil`? EOF is not exceptional. Every file has one.
-			while true
-				result = @io.read_nonblock(size, buffer, exception: false)
-				
-				case result
-				when :wait_readable
-					@io.wait_readable(@io.timeout) or raise ::IO::TimeoutError, "read timeout"
-				when :wait_writable
-					@io.wait_writable(@io.timeout) or raise ::IO::TimeoutError, "write timeout"
-				else
-					return result
+			normalize_read_errors do
+				# Come on Ruby, why couldn't this just return `nil`? EOF is not exceptional. Every file has one.
+				while true
+					result = @io.read_nonblock(size, buffer, exception: false)
+					
+					case result
+					when :wait_readable
+						@io.wait_readable(@io.timeout) or raise ::IO::TimeoutError, "read timeout"
+					when :wait_writable
+						@io.wait_writable(@io.timeout) or raise ::IO::TimeoutError, "write timeout"
+					else
+						break result
+					end
 				end
 			end
+		end
+		
+		private
+		
+		def normalize_read_errors
+			return yield
 		rescue OpenSSL::SSL::SSLError => error
 			if error.message =~ /unexpected eof while reading/
 				raise ConnectionResetError, "Connection reset by peer!"
 			end
+			
+			raise
 		rescue Errno::ECONNRESET
 			raise ConnectionResetError, "Connection reset by peer!"
 		rescue Errno::EBADF

--- a/test/io/stream/tls_readable.rb
+++ b/test/io/stream/tls_readable.rb
@@ -78,7 +78,20 @@ describe IO::Stream::Buffered do
 		
 		expect do
 			client.peek_partial(1)
-		end.to raise_exception(OpenSSL::SSL::SSLError)
+		end.to raise_exception(IO::Stream::ConnectionResetError)
+	end
+	
+	it "preserves other TLS errors" do
+		io = Object.new
+		def io.read_nonblock(...)
+			raise OpenSSL::SSL::SSLError, "TLS protocol error"
+		end
+		
+		stream = IO::Stream::Buffered.new(io)
+		
+		expect do
+			stream.peek_partial(1)
+		end.to raise_exception(OpenSSL::SSL::SSLError, message: be == "TLS protocol error")
 	end
 	
 	it "reports when reading an open TLS connection would block" do


### PR DESCRIPTION
Treat OpenSSL unexpected EOF during both blocking and non-blocking reads as IO::Stream::ConnectionResetError.

This keeps peek_partial from leaking a transport-specific SSLError when a TLS peer closes abruptly, while preserving genuine TLS protocol errors unchanged. It also shares the existing read-error normalization between both read paths.

Related to socketry/async-http#223.

Validation:
- 344 tests, 1,829 assertions
- 41 files inspected by RuboCop, no offenses